### PR TITLE
build: add support for 2026.1

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.21" />
+    <option name="version" value="2.3.20" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "jp.s6n.idea"
-version = "0.2.8"
+version = "0.2.9"
 
 kotlin {
   jvmToolchain(21)
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
   intellijPlatform {
-    intellijIdeaUltimate("2025.2.5")
+    intellijIdeaUltimate("2026.1")
     bundledPlugins(
       "org.jetbrains.plugins.textmate",
       "org.jetbrains.plugins.yaml",
@@ -37,7 +37,7 @@ intellijPlatform {
   pluginConfiguration {
     ideaVersion {
       sinceBuild = "243"
-      untilBuild = "253.*"
+      untilBuild = "261.*"
     }
   }
 

--- a/src/main/kotlin/jp/s6n/idea/typespec/lang/TypeSpecFileType.kt
+++ b/src/main/kotlin/jp/s6n/idea/typespec/lang/TypeSpecFileType.kt
@@ -18,5 +18,5 @@ object TypeSpecFileType : FileType, TextMateBackedFileType {
     fun isMyFile(file: PsiFile) = isMyFile(file.virtualFile)
 
     fun isMyFile(file: VirtualFile) =
-        file.fileType == TextMateFileType.INSTANCE && file.extension == defaultExtension
+        file.fileType === TypeSpecFileType && file.extension == defaultExtension
 }


### PR DESCRIPTION
## Summary
- Updated target IntelliJ IDEA version to `2026.1` (`intellijIdeaUltimate`).
- Bumped plugin version from `0.2.8` to `0.2.9`.
- Extended compatible build range to `untilBuild = "261.*"`.
- Updated Kotlin compiler setting in project config to `2.3.20`.

<img width="346" height="66" alt="kép" src="https://github.com/user-attachments/assets/7d6861cb-0f44-475c-9ae6-0f90dd745a86" />

### Build output
```
BUILD SUCCESSFUL in 1m 28s
15 actionable tasks: 2 executed, 13 up-to-date
Configuration cache entry reused.
```