### PR TITLE
fix: improve LSP startup and fix file type detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /.kotlin/
 /build/
 /node_modules/
+/package.json
+/package-lock.json
+/pnpm-lock.yaml

--- a/.idea/IntelliLang.xml
+++ b/.idea/IntelliLang.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="LanguageInjectionConfiguration">
+    <injection language="SQL" injector-id="java">
+      <display-name>AsyncQueryRunner (org.apache.commons.dbutils)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameterCount(2).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("insertBatch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("batch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("insertBatch").withParameterCount(4).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Jodd (jodd.db)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query").withParameterCount(1).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("DbQuery").withParameterCount(2).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query").withParameterCount(2).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(2, psiMethod().withName("DbQuery").withParameterCount(3).definedInClass("jodd.db.DbQuery"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>MyBatis @Select/@Delete/@Insert/@Update</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Delete")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Insert")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Select")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Update")]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>QueryRunner (org.apache.commons.dbutils)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameterCount(2).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("insertBatch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert", "execute").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update", "execute").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("batch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("insertBatch").withParameterCount(4).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert", "execute").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update", "execute").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>R2DBC (io.r2dbc)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("add").definedInClass("io.r2dbc.spi.Batch"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("createStatement").definedInClass("io.r2dbc.spi.Connection"))]]></place>
+    </injection>
+    <injection language="PostgreSQL" injector-id="java">
+      <display-name>Reactiverse Postgres Client (io.reactiverse)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgTransaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgTransaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.axle.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgPool"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Axle SqlClient (io.vertx.axle.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.axle.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.axle.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Mutiny SqlClient (io.vertx.mutiny.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mutiny.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mutiny.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Mutiny SqlConnection (io.vertx.mutiny.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.db2client.DB2Connection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.mssqlclient.MSSQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.pgclient.PgConnection"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SQL Extensions (io.vertx.ext.sql)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.ext.sql.SQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.ext.sql.SQLOperations"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams").definedInClass("io.vertx.ext.sql.SQLConnection"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SQL Reactive Extensions (io.vertx.reactivex.ext.sql)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLOperations"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams", "rxQuerySingle", "rxQuerySingleWithParams", "rxQuery", "rxQueryWithParams", "rxQueryStream", "rxQueryStreamWithParams", "rxUpdate", "rxUpdateWithParams", "rxCall", "rxCallWithParams", "rxExecute", "rxBatchWithParams", "rxBatchCallableWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams", "rxQuerySingle", "rxQuerySingleWithParams", "rxQuery", "rxQueryWithParams", "rxQueryStream", "rxQueryStreamWithParams", "rxUpdate", "rxUpdateWithParams", "rxCall", "rxCallWithParams", "rxExecute", "rxBatchWithParams", "rxBatchCallableWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.AsyncSQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.MySQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.PostgreSQLClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SqlClient (io.vertx.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mssqlclient.MSSQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.SqlClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.SqlConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.Transaction"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SqlClient RxJava2 (io.vertx.reactivex.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.SqlConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.Transaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.mysqlclient.MySQLPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.pgclient.PgPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>jOOQ (org.jooq.DSLContext)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameters("java.lang.String", "java.lang.Object[]...").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "fetch", "fetchLazy", "fetchAsync", "fetchStream", "fetchMany", "fetchOne", "fetchSingle", "fetchOptional", "fetchValue", "fetchOptionalValue", "fetchValues", "execute", "resultQuery").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "fetch", "fetchLazy", "fetchAsync", "fetchStream", "fetchMany", "fetchOne", "fetchSingle", "fetchOptional", "fetchValue", "fetchOptionalValue", "fetchValues", "execute", "resultQuery", "batch").withParameters("java.lang.String").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(psiMethod().withName("batch").withParameters("java.lang.String...").definedInClass("org.jooq.DSLContext"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>rxjava2-jdbc (org.davidmoten.rx.jdbc)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiMethod().withName("value").definedInClass("org.davidmoten.rx.jdbc.annotations.Query")]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("call", "select", "update").definedInClass("org.davidmoten.rx.jdbc.Database"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("call", "select", "update").definedInClass("org.davidmoten.rx.jdbc.TransactedBuilder"))]]></place>
+    </injection>
+  </component>
+</project>

--- a/.idea/intellij-typespec-plugin.iml
+++ b/.idea/intellij-typespec-plugin.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/intellij-typespec-plugin.iml" filepath="$PROJECT_DIR$/.idea/intellij-typespec-plugin.iml" />
+    </modules>
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing
+
+This document covers setting up a development environment, running the plugin locally, debugging, and cutting a release.
+
+## Prerequisites
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| [mise](https://mise.jdx.dev/) | Manages Java version automatically | `brew install mise` |
+| Java 21 | Build toolchain | Managed by mise (see below) |
+| [GitHub CLI](https://cli.github.com/) | Releases only | `brew install gh && gh auth login` |
+
+> [!NOTE]
+> mise handles Java installation. If you already have Java 21 on `PATH`, you can skip mise and use `./gradlew` directly — but version consistency is not guaranteed.
+
+## Setup
+
+```bash
+git clone https://github.com/<your-username>/intellij-typespec-plugin
+cd intellij-typespec-plugin
+mise install        # installs Java 21 as specified in mise.toml
+```
+
+## Running the Plugin
+
+Launch a sandbox IntelliJ IDEA instance with the plugin loaded:
+
+```bash
+mise run run
+# equivalent to:
+./gradlew runIde
+```
+
+The sandbox IDE opens as a separate process. Your main IDE is unaffected.
+
+### Preparing a Test Project
+
+The `examples/` directory contains sample TypeSpec files covering syntax, folding, LSP features, and navigation.
+
+On first use, install the TypeSpec compiler inside `examples/`:
+
+```bash
+cd examples && npm install
+```
+
+Then, in the sandbox IDE:
+
+1. Open the `examples/` directory as a project (**File > Open...**).
+2. Open any `*.tsp` file.
+3. Confirm the **TypeSpec** widget appears in the bottom status bar — this indicates the LSP server started successfully.
+
+## Debugging
+
+### Viewing Logs
+
+```bash
+tail -f .intellijPlatform/sandbox/intellij-typespec-plugin/IU-*/log/idea.log | grep -i typespec
+```
+
+A successful LSP startup produces output like:
+
+```
+INFO - TypeSpec file opened: /path/to/file.tsp
+INFO - Node.js interpreter found: /usr/local/bin/node
+INFO - TypeSpec LSP server starting with root: [/path/to/examples]
+```
+
+### Common Issues
+
+| Symptom | Likely Cause | Resolution |
+|---------|-------------|------------|
+| `File is not a supported TypeSpec file` in logs | File type not recognized on first open | Restart the sandbox IDE |
+| `Node.js interpreter not found` notification | Node.js not configured in the sandbox IDE | **Settings > Languages & Frameworks > Node.js** — select a Node.js interpreter |
+| `TypeSpec is not installed` notification | `@typespec/compiler` not found in the project tree | Run `npm install @typespec/compiler` in the project root, then reopen a `.tsp` file |
+| No TypeSpec widget in status bar | LSP server failed to start | Check logs for any error after `TypeSpec file opened` |
+
+## Building
+
+```bash
+mise run build
+# equivalent to:
+./gradlew buildPlugin
+```
+
+Output artifact: `build/distributions/intellij-typespec-plugin-<version>.zip`
+
+## Releasing
+
+### 1. Update the version
+
+Edit `build.gradle.kts`:
+
+```kotlin
+version = "0.x.x"
+```
+
+Commit the change:
+
+```bash
+git add build.gradle.kts
+git commit -m "chore: bump version to 0.x.x"
+```
+
+### 2. Build and publish
+
+```bash
+mise run release
+```
+
+This task:
+1. Runs `./gradlew buildPlugin` to produce the zip.
+2. Derives the tag name from `build.gradle.kts` (e.g., `v0.3.1`).
+3. Creates a GitHub Release via `gh release create` and uploads the zip with auto-generated release notes.
+
+Requires `gh auth login` beforehand.
+
+### 3. Installing a release build
+
+Download the `.zip` from the [Releases page](../../releases), then in IntelliJ:
+
+**Settings > Plugins > ⚙️ > Install Plugin from Disk...**
+
+## Architecture
+
+```
+src/main/kotlin/jp/s6n/idea/typespec/
+├── actions/
+│   └── CreateTypeSpecFileAction.kt          # "New File > TypeSpec File" action
+├── folding/
+│   └── TypeSpecFoldingBuilder.kt            # Code folding
+├── icons/
+│   └── TypeSpecIcons.kt
+├── lang/
+│   ├── TypeSpecFileType.kt                  # File type definition (.tsp)
+│   └── TypeSpecStructureViewFactory.kt      # Structure view (Outline panel)
+├── lsp/
+│   ├── TypeSpecLspServerSupportProvider.kt  # LSP server lifecycle (start/stop)
+│   ├── TypeSpecLspServerDescriptor.kt       # LSP command line and configuration
+│   └── LspServerUtil.kt                     # Server lookup helpers
+└── textmate/
+    └── TypeSpecTextMateBundleProvider.kt    # Syntax highlighting via TextMate grammar
+```
+
+### LSP Startup Flow
+
+1. A `.tsp` (or `tspconfig.yaml`) file is opened in the editor.
+2. `TypeSpecLspServerSupportProvider.fileOpened()` is called by the platform.
+3. The configured Node.js interpreter is resolved via the IDE's Node.js settings.
+4. The plugin walks up the directory tree looking for `node_modules/@typespec/compiler/cmd/tsp-server.js`.
+5. On success, the LSP server is started as `node tsp-server.js --stdio`.
+
+### IDE Version Compatibility
+
+The plugin targets `sinceBuild = "243"` (IntelliJ IDEA 2024.3) with no `untilBuild` constraint, so it runs on all IDE versions from 2024.3 onward without code changes.
+
+To compile against a newer IDE version, update `build.gradle.kts`:
+
+```kotlin
+intellijIdeaUltimate("2026.1")  // change to the target version
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,57 @@
-<img src="/src/main/resources/META-INF/pluginIcon.svg" alt="" width="128" height="128" />
+<img src="/src/main/resources/META-INF/pluginIcon.svg" alt="TypeSpec Plugin Icon" width="128" height="128" />
 
-# TypeSpec Language Support Plugin for IntelliJ Platform
+# TypeSpec Language Support for IntelliJ Platform
 
-## Prerequisites
+IntelliJ Platform plugin that provides [TypeSpec](https://typespec.io/) language support via the official LSP integration.
 
-- JetBrains IDE 2024.3 or later
-
-> [!NOTE]
-> This plugin cannot be installed on Community IDEs as the plugin is built on top of the official LSP integration,
-> which is only available in paid IDEs.
+This is a personal fork of [siketyan/intellij-typespec-plugin](https://github.com/siketyan/intellij-typespec-plugin). All original work and credit belong to [@siketyan](https://github.com/siketyan). This fork is maintained for personal use and distributed under the same [MIT License](LICENCE).
 
 ## Features
 
-- Syntax highlighting
-- Code folding
-- Structure view
-- Diagnostics
-- Quick fixes
-- Go to definition
-- Find usages
+| Feature | Status |
+|---------|--------|
+| Syntax highlighting | |
+| Code folding | |
+| Structure view (Outline panel) | |
+| Diagnostics | |
+| Quick fixes | |
+| Go to definition | |
+| Find usages | |
+
+## Requirements
+
+- JetBrains IDE **2024.3 or later** (IntelliJ IDEA Ultimate, WebStorm, GoLand, or any paid JetBrains IDE)
+- **Node.js** configured in IDE settings
+- **`@typespec/compiler`** installed in your project (`npm install @typespec/compiler`)
+
+> [!NOTE]
+> This plugin requires a **paid JetBrains IDE**. It relies on the IntelliJ Platform LSP API, which is not available in Community editions.
+
+## Installation
+
+### From GitHub Releases (recommended)
+
+1. Download the latest `.zip` from the [Releases page](../../releases).
+2. In your IDE, open **Settings > Plugins > ⚙️ > Install Plugin from Disk...**.
+3. Select the downloaded `.zip` file and restart the IDE.
+
+### From Source
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions.
+
+## Usage
+
+1. Configure a Node.js interpreter: **Settings > Languages & Frameworks > Node.js**.
+2. Ensure `@typespec/compiler` is installed in your project root:
+   ```bash
+   npm install @typespec/compiler
+   ```
+3. Open any `*.tsp` file. The LSP server starts automatically and a **TypeSpec** widget appears in the status bar.
+
+## Upstream
+
+This fork tracks [siketyan/intellij-typespec-plugin](https://github.com/siketyan/intellij-typespec-plugin). Upstream changes are periodically merged. Bug reports and feature requests that are not fork-specific should be directed to the upstream repository.
+
+## License
+
+[MIT License](LICENCE) — Copyright (c) 2024 Naoki Ikeguchi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "jp.s6n.idea"
-version = "0.2.9"
+version = "0.3.0"
 
 kotlin {
   jvmToolchain(21)
@@ -37,7 +37,6 @@ intellijPlatform {
   pluginConfiguration {
     ideaVersion {
       sinceBuild = "243"
-      untilBuild = "261.*"
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "jp.s6n.idea"
-version = "0.3.0"
+version = "0.3.1"
 
 kotlin {
   jvmToolchain(21)

--- a/examples/.idea/.gitignore
+++ b/examples/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/examples/.idea/examples.iml
+++ b/examples/.idea/examples.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/examples/.idea/misc.xml
+++ b/examples/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/examples/.idea/modules.xml
+++ b/examples/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/examples.iml" filepath="$PROJECT_DIR$/.idea/examples.iml" />
+    </modules>
+  </component>
+</project>

--- a/examples/.idea/vcs.xml
+++ b/examples/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+プラグインの動作確認用サンプルファイル集です。
+
+## ファイル一覧
+
+| ファイル | 確認できる機能 |
+|---|---|
+| `basic.tsp` | シンタックスハイライト、基本的な TypeSpec 構文 |
+| `navigation.tsp` | Go to Declaration (Cmd+Click / Ctrl+Click) |
+| `folding.tsp` | コードフォールディング (namespace / model / interface ブロック) |
+| `structure.tsp` | Structure View (ファイル構造ツリー) |
+| `lsp.tsp` | LSP 機能 (補完・ホバー・診断・`@doc` 表示) |
+
+## 前提条件
+
+LSP 機能 (`lsp.tsp`) を確認するには `@typespec/compiler` がインストールされている必要があります。
+
+```bash
+npm install -g @typespec/compiler
+```
+
+## 使い方
+
+1. IntelliJ IDEA でプラグインをビルド・起動 (`./gradlew runIde`)
+2. `examples/` ディレクトリを開く
+3. 各ファイルを開いて該当機能を確認

--- a/examples/basic.tsp
+++ b/examples/basic.tsp
@@ -1,0 +1,35 @@
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+@service({
+  title: "Basic Example",
+  version: "1.0.0",
+})
+namespace BasicExample;
+
+model Pet {
+  id: int32;
+  name: string;
+  age?: int32;
+  kind: "cat" | "dog" | "bird";
+}
+
+model PetList {
+  items: Pet[];
+  total: int32;
+}
+
+model ErrorResponse {
+  code: int32;
+  message: string;
+}
+
+@route("/pets")
+interface Pets {
+  @get list(): PetList | ErrorResponse;
+  @get read(@path id: int32): Pet | ErrorResponse;
+  @post create(@body pet: Omit<Pet, "id">): Pet | ErrorResponse;
+  @put update(@path id: int32, @body pet: Omit<Pet, "id">): Pet | ErrorResponse;
+  @delete remove(@path id: int32): void | ErrorResponse;
+}

--- a/examples/folding.tsp
+++ b/examples/folding.tsp
@@ -1,0 +1,44 @@
+// コードフォールディングのテスト用
+// namespace / model / interface / op ブロックが折りたためることを確認
+
+namespace Folding {
+  namespace Inner {
+    model DeepModel {
+      field1: string;
+      field2: int32;
+      field3: boolean;
+      nested: {
+        a: string;
+        b: string;
+      };
+    }
+  }
+}
+
+model LargeModel {
+  id: int32;
+  createdAt: utcDateTime;
+  updatedAt: utcDateTime;
+  title: string;
+  description: string;
+  status: "active" | "inactive" | "pending";
+  metadata: Record<string>;
+  tags: string[];
+  priority: int32;
+  assignee: string;
+}
+
+interface LargeInterface {
+  op1(): void;
+  op2(): void;
+  op3(): void;
+  op4(): void;
+  op5(): void;
+}
+
+union Status {
+  active: "active";
+  inactive: "inactive";
+  pending: "pending";
+  deleted: "deleted";
+}

--- a/examples/lsp.tsp
+++ b/examples/lsp.tsp
@@ -1,0 +1,52 @@
+// LSP 機能 (補完・ホバー・診断) のテスト用
+// typespec-language-server が起動していることが前提
+
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+@service({
+  title: "LSP Test",
+  version: "0.1.0",
+})
+namespace LspTest;
+
+// 補完テスト: "@" を入力してデコレータ候補が出るか確認
+// ホバーテスト: 型名の上にカーソルを置いて説明が表示されるか確認
+// 診断テスト: 意図的なエラーを入れて赤下線が出るか確認
+
+scalar Uuid extends string;
+
+@doc("ユーザーを表すモデル")
+model User {
+  @doc("ユーザーの一意識別子")
+  id: Uuid;
+
+  @doc("表示名")
+  @minLength(1)
+  @maxLength(100)
+  name: string;
+
+  @doc("メールアドレス")
+  @format("email")
+  email: string;
+
+  @doc("作成日時")
+  createdAt: utcDateTime;
+}
+
+@route("/users")
+@tag("Users")
+interface Users {
+  @summary("ユーザー一覧取得")
+  @get list(
+    @query skip?: int32,
+    @query top?: int32,
+  ): User[];
+
+  @summary("ユーザー取得")
+  @get read(@path id: Uuid): User;
+
+  @summary("ユーザー作成")
+  @post create(@body body: Omit<User, "id" | "createdAt">): User;
+}

--- a/examples/navigation.tsp
+++ b/examples/navigation.tsp
@@ -1,0 +1,36 @@
+// Go to Declaration のテスト用
+// 各シンボルで Cmd+Click / Ctrl+Click して宣言にジャンプできることを確認
+
+namespace Navigation;
+
+model Address {
+  street: string;
+  city: string;
+  country: string;
+}
+
+model User {
+  id: int32;
+  name: string;
+  email: string;
+  address: Address; // Address にジャンプできるか確認
+}
+
+model Order {
+  id: int32;
+  user: User;       // User にジャンプできるか確認
+  items: OrderItem[];
+  total: float32;
+}
+
+model OrderItem {
+  productId: int32;
+  quantity: int32;
+  price: float32;
+}
+
+alias UserId = int32;   // エイリアスへのジャンプ確認
+
+model AdminUser extends User {  // User 継承でジャンプ確認
+  role: "admin" | "superadmin";
+}

--- a/examples/structure.tsp
+++ b/examples/structure.tsp
@@ -1,0 +1,60 @@
+// Structure View (ファイル構造ツリー) のテスト用
+// エディタ右側や Project ツールウィンドウでの構造表示を確認
+
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/openapi3";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+
+@service({ title: "Structure View Example" })
+namespace StructureExample {
+  namespace Models {
+    model Product {
+      id: int32;
+      name: string;
+      price: float32;
+      category: Category;
+    }
+
+    model Category {
+      id: int32;
+      name: string;
+    }
+
+    model Cart {
+      id: string;
+      items: CartItem[];
+    }
+
+    model CartItem {
+      product: Product;
+      quantity: int32;
+    }
+  }
+
+  namespace Interfaces {
+    using Models;
+
+    @route("/products")
+    interface Products {
+      @get list(): Product[];
+      @get read(@path id: int32): Product;
+      @post create(@body body: Omit<Product, "id">): Product;
+    }
+
+    @route("/categories")
+    interface Categories {
+      @get list(): Category[];
+      @get read(@path id: int32): Category;
+    }
+
+    @route("/cart")
+    interface Carts {
+      @get get(@path cartId: string): Cart;
+      @post addItem(@path cartId: string, @body item: CartItem): Cart;
+      @delete removeItem(@path cartId: string, @path productId: int32): Cart;
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ org.gradle.configuration-cache = true
 
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
+
+org.gradle.parallel = true
+org.gradle.daemon = true

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[tools]
+java = "zulu-21.50.19.0"
+
+[tasks.run]
+run = "./gradlew runIde"
+description = "Run IntelliJ IDEA with the plugin"
+
+[tasks.build]
+run = "./gradlew buildPlugin"
+description = "Build plugin zip to build/distributions/"
+
+[tasks.release]
+run = "gh release create v$(grep '^version' build.gradle.kts | head -1 | grep -o '\".*\"' | tr -d '\"') build/distributions/*.zip --generate-notes"
+description = "Create GitHub release with built plugin"
+depends = ["build"]

--- a/src/main/kotlin/jp/s6n/idea/typespec/lang/TypeSpecFileType.kt
+++ b/src/main/kotlin/jp/s6n/idea/typespec/lang/TypeSpecFileType.kt
@@ -17,6 +17,5 @@ object TypeSpecFileType : FileType, TextMateBackedFileType {
 
     fun isMyFile(file: PsiFile) = isMyFile(file.virtualFile)
 
-    fun isMyFile(file: VirtualFile) =
-        file.fileType === TypeSpecFileType && file.extension == defaultExtension
+    fun isMyFile(file: VirtualFile) = file.extension == defaultExtension
 }

--- a/src/main/kotlin/jp/s6n/idea/typespec/lsp/LspServerUtil.kt
+++ b/src/main/kotlin/jp/s6n/idea/typespec/lsp/LspServerUtil.kt
@@ -4,11 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerManager
-import kotlin.io.path.relativeToOrNull
 
-/**
- * Hacky LSP server integration utilities to use officially unsupported requests of LSP.
- */
 object LspServerUtil {
     fun getServerManager(project: Project): LspServerManager =
         LspServerManager.getInstance(project)
@@ -18,6 +14,6 @@ fun LspServerManager.findServerForFile(file: VirtualFile): LspServer? =
     getServersForProvider(TypeSpecLspServerSupportProvider::class.java)
         .find { server ->
             server.descriptor.roots.any {
-                file.toNioPath().relativeToOrNull(it.toNioPath()) != null
+                file.toNioPath().startsWith(it.toNioPath())
             }
         }

--- a/src/main/kotlin/jp/s6n/idea/typespec/lsp/TypeSpecLspServerDescriptor.kt
+++ b/src/main/kotlin/jp/s6n/idea/typespec/lsp/TypeSpecLspServerDescriptor.kt
@@ -20,6 +20,7 @@ class TypeSpecLspServerDescriptor(
 ) : LspServerDescriptor(project, "TypeSpec", root) {
     private val commandLineConfigurator = NodeCommandLineConfigurator.find(interpreter)
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override val lspSemanticTokensSupport = object : LspSemanticTokensSupport() {
         override fun getTextAttributesKey(tokenType: String, modifiers: List<String>) =
             when (tokenType) {

--- a/src/main/kotlin/jp/s6n/idea/typespec/lsp/TypeSpecLspServerSupportProvider.kt
+++ b/src/main/kotlin/jp/s6n/idea/typespec/lsp/TypeSpecLspServerSupportProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.findDirectory
@@ -14,15 +15,36 @@ import com.intellij.platform.lsp.api.LspServerSupportProvider
 import com.intellij.platform.lsp.api.lsWidget.LspServerWidgetItem
 import jp.s6n.idea.typespec.icons.TypeSpecIcons
 
+private val LOG = logger<TypeSpecLspServerSupportProvider>()
+
 class TypeSpecLspServerSupportProvider : LspServerSupportProvider {
     override fun fileOpened(
         project: Project,
         file: VirtualFile,
         serverStarter: LspServerSupportProvider.LspServerStarter
     ) {
-        if (!TypeSpecLspServerDescriptor.isSupportedFile(file)) return
+        if (!TypeSpecLspServerDescriptor.isSupportedFile(file)) {
+            LOG.info("File is not a supported TypeSpec file: ${file.name} (fileType=${file.fileType.name}, ext=${file.extension})")
+            return
+        }
 
-        val interpreter = NodeJsInterpreterManager.getInstance(project).getInterpreter(true) ?: return
+        LOG.info("TypeSpec file opened: ${file.path}")
+
+        val interpreter = NodeJsInterpreterManager.getInstance(project).getInterpreter(true)
+        if (interpreter == null) {
+            LOG.warn("Node.js interpreter not configured")
+            Notifications.Bus.notify(
+                Notification(
+                    "TypeSpec",
+                    "Node.js interpreter not found",
+                    "Please configure a Node.js interpreter in Settings > Languages & Frameworks > Node.js.",
+                    NotificationType.WARNING,
+                )
+            )
+            return
+        }
+
+        LOG.info("Node.js interpreter found: $interpreter")
 
         val descriptor = findTspServer(project, interpreter, file.parent ?: return) ?: return Notifications.Bus.notify(
             Notification(
@@ -33,6 +55,7 @@ class TypeSpecLspServerSupportProvider : LspServerSupportProvider {
             )
         )
 
+        LOG.info("TypeSpec LSP server starting with root: ${descriptor.roots}")
         serverStarter.ensureServerStarted(descriptor)
     }
 


### PR DESCRIPTION
## Summary

- Fix `.tsp` file type detection: use extension-only check instead of fileType identity check, which rejected TextMate-backed files
- Fix `findServerForFile` to use `startsWith` instead of `relativeToOrNull` (which matched files across the entire volume)
- Remove custom `TypeSpecGotoDeclarationHandler` in favour of the built-in LSP Go to Declaration (available since IntelliJ 2023.2)
- Add mise tasks (`run`, `build`, `release`) and enable parallel Gradle builds
- Rewrite README and add CONTRIBUTING.md with setup, debug, and release instructions

## Test plan

- [ ] Open a `.tsp` file in the sandbox IDE (`mise run run`) — TypeSpec widget appears in status bar
- [ ] Go to Declaration (Cmd+B / Cmd+Click) navigates to user-defined symbol declarations
- [ ] `mise run build` produces a zip in `build/distributions/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)